### PR TITLE
Rework controllers and views a bit

### DIFF
--- a/Controller/BaseController.php
+++ b/Controller/BaseController.php
@@ -7,6 +7,7 @@ use Rizza\CalendarBundle\Model\CalendarManagerInterface;
 use Rizza\CalendarBundle\Model\EventManagerInterface;
 use Rizza\CalendarBundle\Form\Factory\CalendarFormFactoryInterface;
 use Rizza\CalendarBundle\Form\Factory\EventFormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 abstract class BaseController extends ContainerAware
 {
@@ -30,7 +31,7 @@ abstract class BaseController extends ContainerAware
     /**
      * @return CalendarFormFactoryInterface
      */
-    public function getCalendarFormFactory()
+    protected function getCalendarFormFactory()
     {
         return $this->container->get('rizza_calendar.form_factory.calendar');
     }
@@ -38,9 +39,14 @@ abstract class BaseController extends ContainerAware
     /**
      * @return EventFormFactoryInterface
      */
-    public function getEventFormFactory()
+    protected function getEventFormFactory()
     {
         return $this->container->get('rizza_calendar.form_factory.event');
+    }
+
+    protected function createRedirect($controller, $action, $data = array())
+    {
+        return new RedirectResponse($this->container->get('router')->generate($this->container->getParameter(sprintf('rizza_calendar.routing.%s.%s', $controller, $action)), $data));
     }
 
 }

--- a/Controller/CalendarController.php
+++ b/Controller/CalendarController.php
@@ -10,13 +10,26 @@ class CalendarController extends BaseController
     public function listAction()
     {
         $user = $this->container->get('security.context')->getToken()->getUser();
-        if (!is_object($user)) {
-            $user = null;
-        }
         $calendars = $this->getCalendarManager()->findVisible($user);
 
         return $this->container->get('templating')->renderResponse('RizzaCalendarBundle:Calendar:list.html.twig', array(
             'calendars' => $calendars,
+        ));
+    }
+
+    public function listEventsAction($id)
+    {
+        $calendar = $this->getCalendarManager()->find($id);
+
+        if (!$this->container->get('security.context')->isGranted('view', $calendar)) {
+            throw new AccessDeniedException();
+        }
+
+        $events = $calendar->getEvents();
+
+        return $this->container->get('templating')->renderResponse('RizzaCalendarBundle:Calendar:listEvents.html.twig', array(
+            'events' => $events,
+            'calendar' => $calendar,
         ));
     }
 

--- a/Controller/EventController.php
+++ b/Controller/EventController.php
@@ -3,18 +3,18 @@
 namespace Rizza\CalendarBundle\Controller;
 
 use Symfony\Component\HttpFoundation\Request;
-use Rizza\CalendarBundle\Form\Type\EventType;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class EventController extends BaseController
 {
-    public function listAction()
+    public function listAction($calendarId)
     {
-        $events = $this->getEventManager()->findAll();
+        $calendar = $this->getCalendarManager()->find($calendarId);
+        $events = $calendar->getEvents();
 
         return $this->container->get('templating')->renderResponse('RizzaCalendarBundle:Event:list.html.twig', array(
             'events' => $events,
+            'calendar' => $calendar,
         ));
     }
 
@@ -48,7 +48,9 @@ class EventController extends BaseController
 
             if ($form->isValid() && $this->container->get('rizza_calendar.creator.event')->create($event)) {
                 // @todo add flash
-                return new RedirectResponse($this->container->get('router')->generate($this->container->getParameter('rizza_calendar.routing.event.list')));
+                return $this->createRedirect('event', 'show', array(
+                    'id' => $event->getId(),
+                ));
             }
         }
 
@@ -74,7 +76,9 @@ class EventController extends BaseController
 
             if ($form->isValid() && $manager->updateEvent($event)) {
                 // @todo add flash
-                return new RedirectResponse($this->container->get('router')->generate($this->container->getParameter('rizza_calendar.routing.event.list')));
+                return $this->createRedirect('event', 'show', array(
+                    'id' => $event->getId(),
+                ));
             }
         }
 
@@ -84,7 +88,7 @@ class EventController extends BaseController
         ));
     }
 
-    public function deleteAction($id)
+    public function deleteAction($id, Request $request)
     {
         $manager = $this->getEventManager();
         $event = $manager->find($id);
@@ -93,9 +97,19 @@ class EventController extends BaseController
             throw new AccessDeniedException();
         }
 
-        $manager->removeEvent($event);
+        if ('POST' === $request->getMethod()) {
+            $calendarId = $event->getCalendar()->getId();
+            $manager->removeEvent($event);
 
-        return new RedirectResponse($this->container->get('router')->generate($this->container->getParameter('rizza_calendar.routing.event.list')));
+            return $this->createRedirect('event', 'list', array(
+                'calendarId' => $calendarId,
+            ));
+        }
+
+        return $this->container->get('templating')->renderResponse('RizzaCalendarBundle:Event:delete.html.twig', array(
+            'event' => $event,
+        ));
+
     }
 
 }

--- a/Controller/EventController.php
+++ b/Controller/EventController.php
@@ -7,14 +7,13 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class EventController extends BaseController
 {
-    public function listAction($calendarId)
+    public function listAction()
     {
-        $calendar = $this->getCalendarManager()->find($calendarId);
-        $events = $calendar->getEvents();
+        $user = $this->container->get('security.context')->getToken()->getUser();
+        $events = $this->getEventManager()->findVisible($user);
 
         return $this->container->get('templating')->renderResponse('RizzaCalendarBundle:Event:list.html.twig', array(
             'events' => $events,
-            'calendar' => $calendar,
         ));
     }
 

--- a/Entity/EventManager.php
+++ b/Entity/EventManager.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityRepository;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Rizza\CalendarBundle\Model\EventInterface;
 use Rizza\CalendarBundle\Blamer\EventBlamerInterface;
+use Rizza\CalendarBundle\Model\CalendarInterface;
 
 class EventManager extends BaseEventManager
 {
@@ -60,7 +61,7 @@ class EventManager extends BaseEventManager
     {
         $event = $this->repo->find($id);
         if (null === $event) {
-            throw new NotFoundHttpException();
+            throw new NotFoundHttpException(sprintf("Couldn't find event with id '%d'", $id));
         }
 
         return $event;

--- a/Entity/EventManager.php
+++ b/Entity/EventManager.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Rizza\CalendarBundle\Model\EventInterface;
 use Rizza\CalendarBundle\Blamer\EventBlamerInterface;
 use Rizza\CalendarBundle\Model\CalendarInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class EventManager extends BaseEventManager
 {
@@ -70,6 +71,25 @@ class EventManager extends BaseEventManager
     public function findAll()
     {
         return $this->repo->findAll();
+    }
+
+    public function findVisible($organizer)
+    {
+        if (!$organizer instanceof UserInterface) {
+            $organizer = null;
+        }
+        $qb = $this->repo->createQueryBuilder('e');
+        $qb
+            ->join('e.calendar', 'c')
+            ->andWhere('e.organizer = :organizer')
+            ->orWhere('c.visibility = :calendarVisibility')
+        ;
+        $qb->setParameters(array(
+            'organizer' => $organizer,
+            'calendarVisibility' => CalendarInterface::VISIBILITY_PUBLIC,
+        ));
+
+        return $qb->getQuery()->execute();
     }
 
     public function getClass()

--- a/Model/CalendarManagerInterface.php
+++ b/Model/CalendarManagerInterface.php
@@ -2,6 +2,8 @@
 
 namespace Rizza\CalendarBundle\Model;
 
+use Symfony\Component\Security\Core\User\UserInterface;
+
 interface CalendarManagerInterface
 {
 
@@ -32,6 +34,8 @@ interface CalendarManagerInterface
     public function find($id);
 
     public function findAll();
+
+    public function findVisible($user);
 
     public function getClass();
 

--- a/Model/EventManagerInterface.php
+++ b/Model/EventManagerInterface.php
@@ -33,6 +33,8 @@ interface EventManagerInterface
 
     public function findAll();
 
+    public function findVisible($organizer);
+
     public function getClass();
 
 }

--- a/Resources/config/routing/calendar.yml
+++ b/Resources/config/routing/calendar.yml
@@ -2,6 +2,10 @@ rizza_calendar_list:
   pattern:  /
   defaults: { _controller: RizzaCalendarBundle:Calendar:list }
 
+rizza_calendar_listEvents:
+  pattern:  /{id}/events
+  defaults: { _controller: RizzaCalendarBundle:Calendar:listEvents }
+
 rizza_calendar_show:
   pattern:  /show/{id}
   defaults: { _controller: RizzaCalendarBundle:Calendar:show }

--- a/Resources/config/routing/event.yml
+++ b/Resources/config/routing/event.yml
@@ -1,5 +1,5 @@
 rizza_calendar_event_list:
-  pattern:  /
+  pattern:  /{calendarId}
   defaults: { _controller: RizzaCalendarBundle:Event:list }
 
 rizza_calendar_event_show:

--- a/Resources/config/routing/event.yml
+++ b/Resources/config/routing/event.yml
@@ -1,5 +1,5 @@
 rizza_calendar_event_list:
-  pattern:  /{calendarId}
+  pattern:  /
   defaults: { _controller: RizzaCalendarBundle:Event:list }
 
 rizza_calendar_event_show:

--- a/Resources/views/Calendar/add.html.twig
+++ b/Resources/views/Calendar/add.html.twig
@@ -1,5 +1,5 @@
 {% extends "RizzaCalendarBundle::layout.html.twig" %}
-{% block content %}
+{% block rizza_calendar_content %}
 <form action="{{ path(rizza_calendar_route('calendar', 'add')) }}" {{ form_enctype(form) }} method="POST">
     {{ form_errors(form) }}
 
@@ -9,4 +9,4 @@
     
     <input type="submit" value="Create Calendar" />
 </form>
-{% endblock content %}
+{% endblock rizza_calendar_content %}

--- a/Resources/views/Calendar/delete.html.twig
+++ b/Resources/views/Calendar/delete.html.twig
@@ -1,0 +1,9 @@
+{% extends "RizzaCalendarBundle::layout.html.twig" %}
+
+{% block rizza_calendar_content %}
+<form method="post">
+    <h3>Are you SURE you want to delete the calendar {{ calendar.getName() }}? This cannot be undone!</h3>
+    <input type="submit" value="Confirm" />
+    <a href="{{ path(rizza_calendar_route('calendar', 'show'), {'id': calendar.getId()}) }}">Cancel</a>
+</form>
+{% endblock rizza_calendar_content %}

--- a/Resources/views/Calendar/edit.html.twig
+++ b/Resources/views/Calendar/edit.html.twig
@@ -1,5 +1,5 @@
 {% extends "RizzaCalendarBundle::layout.html.twig" %}
-{% block content %}
+{% block rizza_calendar_content %}
 <h2>Edit &quot;{{ calendar.getName() }}&quot;</h2>
 <form action="{{ path(rizza_calendar_route('calendar', 'edit'), { 'id': calendar.getId() }) }}" {{ form_enctype(form) }} method="POST">
     {{ form_errors(form) }}
@@ -10,4 +10,4 @@
 
     <input type="submit" value="Edit Calendar" />
 </form>
-{% endblock content %}
+{% endblock rizza_calendar_content %}

--- a/Resources/views/Calendar/list.html.twig
+++ b/Resources/views/Calendar/list.html.twig
@@ -1,10 +1,10 @@
 {% extends "RizzaCalendarBundle::layout.html.twig" %}
-{% block content %}
-<div class="calendar_list">
-    <ul>
-        {% for calendar in calendars %}
-        <li><a href="{{ path(rizza_calendar_route('calendar', 'show'), {'id': calendar.getId()} ) }}">{{ calendar.getName() }}</li>
-        {% endfor %}
-    </ul>
-</div>
-{% endblock content %}
+{% block rizza_calendar_content %}
+<h3>Your calendars:</h3>
+<ul class="calendar_list">
+{% for calendar in calendars %}
+    <li><a href="{{ path(rizza_calendar_route('calendar', 'show'), {'id': calendar.getId()} ) }}">{{ calendar.getName() }}</a> (owned by {{ calendar.getOwner() ? calendar.getOwner().getUsername() : 'the community' }})</li>
+{% endfor %}
+</ul>
+<p>{% if calendars is empty %}None yet. {% endif %}<a href="{{ path(rizza_calendar_route('calendar', 'add')) }}">Create a new calendar?</a></p>
+{% endblock rizza_calendar_content %}

--- a/Resources/views/Calendar/show.html.twig
+++ b/Resources/views/Calendar/show.html.twig
@@ -1,13 +1,19 @@
 {% extends "RizzaCalendarBundle::layout.html.twig" %}
-{% block content %}
-This is the {{ calendar.getName() }} calendar. Riveting. 
-  <a href="{{ path(rizza_calendar_route('calendar', 'edit'), { 'id': calendar.getId() }) }}">(edit)</a>
-  <a href="{{ path(rizza_calendar_route('calendar', 'delete'), { 'id': calendar.getId() }) }}">(delete)</a>
+{% block rizza_calendar_content %}
+<h1>Calendar: {{ calendar.getName() }}</h1>
+<p>Owner: {{ calendar.getOwner() ? calendar.getOwner().getUsername() : 'the community' }}</p>
+<p>Visibility: {{ calendar.isPublic ? 'Public' : 'Private' }}</p>
+  {% if is_granted('edit', calendar) %}<a href="{{ path(rizza_calendar_route('calendar', 'edit'), { 'id': calendar.getId() }) }}">(edit)</a>{% endif %}
+  {% if is_granted('delete', calendar) %}<a href="{{ path(rizza_calendar_route('calendar', 'delete'), { 'id': calendar.getId() }) }}">(delete)</a>{% endif %}
 
 {{ calendar|calendarMonth(7, 2011) }}
 
+<h3>Events ({{ calendar.getEvents().count() }})</h3>
+<ul>
 {% for event in calendar.getEvents() %}
-  <a href="{{ path(rizza_calendar_route('event', 'show'), { 'id': event.getId() }) }}">{{ event.getTitle() }}</a>
+    <li><a href="{{ path(rizza_calendar_route('event', 'show'), { 'id': event.getId() }) }}">{{ event.getTitle() }}</a> by {{ event.getOrganizer().getUsername() }}</li>
 {% endfor %}
+</ul>
+<p>{% if calendar.getEvents() is empty %}None yet. {% endif %}<a href="{{ path(rizza_calendar_route('event', 'add'), {'calendarId': calendar.getId()}) }}">Create a new event?</a></p>
 
-{% endblock content %}
+{% endblock rizza_calendar_content %}

--- a/Resources/views/Event/add.html.twig
+++ b/Resources/views/Event/add.html.twig
@@ -1,5 +1,5 @@
 {% extends "RizzaCalendarBundle::layout.html.twig" %}
-{% block content %}
+{% block rizza_calendar_content %}
 <form action="{{ path(rizza_calendar_route('event', 'add'), {"calendarId": calendar.getId()}) }}" {{ form_enctype(form) }} method="POST">
     <p>Adding event for calendar {{ calendar.getName() }}. Riveting.</p>
     {{ form_errors(form) }}
@@ -8,4 +8,4 @@
 
     <input type="submit" value="Create Event" />
 </form>
-{% endblock content %}
+{% endblock rizza_calendar_content %}

--- a/Resources/views/Event/delete.html.twig
+++ b/Resources/views/Event/delete.html.twig
@@ -1,0 +1,9 @@
+{% extends "RizzaCalendarBundle::layout.html.twig" %}
+
+{% block rizza_calendar_content %}
+<form method="post">
+    <h3>Are you SURE you want to delete the event {{ event.getTitle() }}? This cannot be undone!</h3>
+    <input type="submit" value="Confirm" />
+    <a href="{{ path(rizza_calendar_route('event', 'show'), {'id': event.getId()}) }}">Cancel</a>
+</form>
+{% endblock rizza_calendar_content %}

--- a/Resources/views/Event/edit.html.twig
+++ b/Resources/views/Event/edit.html.twig
@@ -1,5 +1,5 @@
 {% extends "RizzaCalendarBundle::layout.html.twig" %}
-{% block content %}
+{% block rizza_calendar_content %}
 <h2>Edit &quot;{{ event.getTitle() }}&quot;</h2>
 <form action="{{ path(rizza_calendar_route('event', 'edit'), { 'id': event.getId() }) }}" {{ form_enctype(form) }} method="POST">
     {{ form_errors(form) }}
@@ -8,4 +8,4 @@
 
     <input type="submit" value="Edit Event" />
 </form>
-{% endblock content %}
+{% endblock rizza_calendar_content %}

--- a/Resources/views/Event/list.html.twig
+++ b/Resources/views/Event/list.html.twig
@@ -1,7 +1,7 @@
 {% extends "RizzaCalendarBundle::layout.html.twig" %}
 {% block rizza_calendar_content %}
 <div class="event_list">
-    <p>Listing events for calendar "{{ calendar.getName() }}"</p>
+    <p>Listing all your events</p>
     <ul>
         {% for event in events %}
         <li><a href="{{ path(rizza_calendar_route('event', 'show'), {'id': event.getId()} ) }}">{{ event.getTitle() }}</li>

--- a/Resources/views/Event/list.html.twig
+++ b/Resources/views/Event/list.html.twig
@@ -1,10 +1,11 @@
 {% extends "RizzaCalendarBundle::layout.html.twig" %}
-{% block content %}
+{% block rizza_calendar_content %}
 <div class="event_list">
+    <p>Listing events for calendar "{{ calendar.getName() }}"</p>
     <ul>
         {% for event in events %}
         <li><a href="{{ path(rizza_calendar_route('event', 'show'), {'id': event.getId()} ) }}">{{ event.getTitle() }}</li>
         {% endfor %}
     </ul>
 </div>
-{% endblock content %}
+{% endblock rizza_calendar_content %}

--- a/Resources/views/Event/show.html.twig
+++ b/Resources/views/Event/show.html.twig
@@ -1,4 +1,4 @@
 {% extends "RizzaCalendarBundle::layout.html.twig" %}
-{% block content %}
+{% block rizza_calendar_content %}
 This is the {{ event.getTitle() }} event. Riveting.
-{% endblock content %}
+{% endblock rizza_calendar_content %}

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -9,15 +9,9 @@
       <em>Notice</em>: {{ app.session.flash('notice') }}
     </div>
     {% endif %}
-    <ul>
-      <li><a href="{{ path(rizza_calendar_route('calendar', 'add')) }}">New Calendar</a></li>
-{% if calendar is defined %}
-      <li><a href="{{ path(rizza_calendar_route('event', 'add'), {"calendarId": calendar.getId()}) }}">New Event</a></li>
-{% endif %}
-    </ul>
     <div>
-      {% block content %}
-      {% endblock content %}
+      {% block rizza_calendar_content %}
+      {% endblock rizza_calendar_content %}
     </div>
   </body>
 </html>


### PR DESCRIPTION
Couple things going on here (I had a really messy cherry-picking session, that's why it's already rebased into one commit):
- Fixed some method visibility inconsistencies in the base controller
- Made the calendar list controller pull only calendars visible to the current user
- Renamed the block "content" to "rizza_calendar_content" for portability
- Various cosmetic changes to views
- Added an intermediary step to delete calendars and events
